### PR TITLE
Bugfixes for calendar.php

### DIFF
--- a/scenesys/scene/calendar.php
+++ b/scenesys/scene/calendar.php
@@ -22,14 +22,12 @@
 
 	  $running_day = date('w',mktime(0,0,0,$month,1,$year));
 	  $days_in_month = date('t',mktime(0,0,0,$month,1,$year));
-	  $days_in_this_week = 1;
 	  $day_counter = 1;
-	  $dates_array = array();
 	  $calendar = array();
 
 	  
 	  for ($x = 1; $x < 36; $x++):
-		if($x < $running_day+1 || $x > $days_in_month)
+		if($x < $running_day+1 || $day_counter > $days_in_month)
 		{
 			$calendar[$x] = ['num'=>False, 'scenes'=>False];
 		}
@@ -54,7 +52,7 @@
 	$cal1 = draw_calendar(date('m'),date('Y'));
 	$cal2 = draw_calendar(date('m')+1,date('Y'));
 		
-	$header = ['1'=>date('F, Y',mktime(0, 0, 0, date("m")+1, date("d"),   date("Y"))), '2'=>date('F, Y',mktime(0, 0, 0, date("m")+1, date("d"),   date("Y")))];
+	$header = ['1'=>date('F, Y',mktime(0, 0, 0, date("m"), date("d"),   date("Y"))), '2'=>date('F, Y',mktime(0, 0, 0, date("m")+1, date("d"),   date("Y")))];
 	
 	$smarty->assign('header',$header);
 	$smarty->assign('cal1', $cal1);


### PR DESCRIPTION
Lines 25 and 27 introduce variables that are never used, cleaned up (/nitpick)
Line 32; Comparing $x > $days_in_month results in last days of the month being dropped out if the month didn't start on a Sunday. Comparison $day_counter > $days_in_month fixes this
Line 57; header for both calendars was the same (next month's)

There also are some issues related to timezones (running MUSH in EST for example saves times as UTC in DB. MUSH shows them correct on +schedule with EST timezone, but the web component will display in UTC. Another issue (not included in this) is +scheduling an event at midnight UTC results in the day being shown on two days. I ended up fixing those by rewriting the logic on how the calendar is created (and adding player-selectable timezone views) so I don't have a specific fixes for those two issues to propose.