### PR TITLE
Bugfix for schedule.php

### DIFF
--- a/scenesys/scene/schedule.php
+++ b/scenesys/scene/schedule.php
@@ -15,7 +15,7 @@
 		
 		$truetime = explode(" ",$schedule_data['schedule_date']);
 		$hourminute = explode(":",$truetime[1]);
-		$scene_time = $truetime[0].":".$truetime[1];
+		$scene_time = $hourminute[0].":".$hourminute[1];
 		
 		$schedule = ['player_name'=>$schedule_data['player_name'],'date'=>$truetime[0],'id'=>$num,'title'=>$schedule_data['schedule_title'],'desc'=>$schedule_data['schedule_desc'],'time'=>$scene_time];
 		


### PR DESCRIPTION
$truetime was used in forming $scene_time, resulting in schedule.php showing date twice alongside full time.